### PR TITLE
Fix CoreLogic signal declaration

### DIFF
--- a/controlunit/core_logic.py
+++ b/controlunit/core_logic.py
@@ -8,10 +8,10 @@ from PyQt5 import QtCore
 
 
 class CoreLogic(QtCore.QObject):
+    plot_update_signal = QtCore.pyqtSignal(object)  # To send data to the plot
+
     def __init__(self):
         super().__init__()
-        # Signals within CoreLogic to centralize communication
-        self.plot_update_signal = QtCore.pyqtSignal(object)  # To send data to the plot
 
     def connect_signals(self, adc_worker, graph):
         # Connect ADC data_ready signal to CoreLogic's plot_update_signal

--- a/tests/test_core_logic_signal.py
+++ b/tests/test_core_logic_signal.py
@@ -1,0 +1,26 @@
+import os
+import sys
+from PyQt5 import QtCore
+
+# Ensure the package is importable when running tests from the tests directory
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from controlunit.core_logic import CoreLogic
+
+
+class Receiver(QtCore.QObject):
+    def __init__(self):
+        super().__init__()
+        self.called = False
+
+    @QtCore.pyqtSlot(object)
+    def slot(self, value):
+        self.called = True
+
+
+def test_plot_update_signal_emits():
+    logic = CoreLogic()
+    receiver = Receiver()
+    logic.plot_update_signal.connect(receiver.slot)
+    logic.plot_update_signal.emit("data")
+    assert receiver.called


### PR DESCRIPTION
## Summary
- Correct Qt signal initialization in `CoreLogic`
- Add regression test ensuring signals connect and emit properly

## Testing
- `pytest -q`
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit)*

------
https://chatgpt.com/codex/tasks/task_e_68969900b96c832ab6119ed054a1a3df